### PR TITLE
Fixing build for Windows against the Katana shipped libraries.

### DIFF
--- a/cmake/macros/Support.cmake
+++ b/cmake/macros/Support.cmake
@@ -199,7 +199,7 @@ function(pxr_library NAME)
     )
     target_link_libraries(
         ${NAME}
-        PRIVATE
+        PUBLIC
         ${args_LIBRARIES}
         $<$<CXX_COMPILER_ID:MSVC>:OPENGL32.lib>
     )

--- a/cmake/modules/FindUSD.cmake
+++ b/cmake/modules/FindUSD.cmake
@@ -23,10 +23,18 @@
 
 #The USD libraries required by the Katana USD Plug-ins
 set(USD_LIBRARIES
+    ar
+    arch
+    cameraUtil
     gf
+    kind
     hio
+    pcp
+    plug
     sdf
     tf
+    trace
+    usd
     usdGeom
     usdHydra
     usdImagingGL
@@ -37,6 +45,7 @@ set(USD_LIBRARIES
     usdUI
     usdUtils
     vt
+    work
 )
 
 if(NOT DEFINED USD_LIBRARY_DIR)

--- a/lib/usdKatana/CMakeLists.txt
+++ b/lib/usdKatana/CMakeLists.txt
@@ -7,8 +7,18 @@ endif()
 
 pxr_shared_library(${PXR_PACKAGE}
     LIBRARIES
+        ar
+        arch
+        cameraUtil
+        gf
+        kind
+        pcp
+        plug
+        tf
+        trace
         vt
         sdf
+        usd
         usdHydra
         usdImagingGL
         usdSkel
@@ -16,7 +26,10 @@ pxr_shared_library(${PXR_PACKAGE}
         usdRi
         usdUI
         usdUtils
+        usdLux
+        usdShade
         hio
+        work
         katanaPluginApi
         ${vtKatana_LIBRARY}
         Boost::system

--- a/lib/usdKatana/utils.h
+++ b/lib/usdKatana/utils.h
@@ -59,28 +59,33 @@ struct PxrUsdKatanaUtils {
 
     /// Reverse a motion time sample. This is used for building
     /// multi-sampled attributes when motion blur is backward.
+    USDKATANA_API
     static double ReverseTimeSample(double sample);
 
     /// Convert Pixar-style numVerts to Katana-style startVerts.
+    USDKATANA_API
     static void ConvertNumVertsToStartVerts( const std::vector<int> &numVertsVec,
                                   std::vector<int> *startVertsVec );
 
+    USDKATANA_API
     static void ConvertArrayToVector(const VtVec3fArray &a, std::vector<float> *r);
 
     /// Convert a VtValue to a Katana attribute.
     /// If asShaderParam is false, convert arrays to type + array pairs
+    USDKATANA_API
     static FnKat::Attribute ConvertVtValueToKatAttr( const VtValue & val,
                                                      bool asShaderParam = true);
 
     /// Extract the targets of a relationship to a Katana attribute.
     /// If asShaderParam is false, convert arrays to type + array pairs
-    static FnKat::Attribute ConvertRelTargetsToKatAttr(
+    USDKATANA_API static FnKat::Attribute ConvertRelTargetsToKatAttr(
             const UsdRelationship &rel, 
             bool asShaderParam = true);
 
     /// Convert a VtValue to a Katana custom geometry attribute (primvar).
     /// Katana uses a different encoding here from other attributes, which
     /// requires the inputType and elementSize attributes.
+    USDKATANA_API
     static void ConvertVtValueToKatCustomGeomAttr( const VtValue & val,
                                         int elementSize,
                                         const TfToken &roleName,
@@ -89,6 +94,7 @@ struct PxrUsdKatanaUtils {
                                         FnKat::Attribute *elementSizeAttr );
 
     /// Returns whether the given attribute is varying over time.
+    USDKATANA_API
     static bool IsAttributeVarying(const UsdAttribute &attr, double currentTime);
 
     /// \brief Get the handle for the given shadingNode.
@@ -98,7 +104,7 @@ struct PxrUsdKatanaUtils {
     /// \p shadingNode until it encounters a prim that is not a Scope.  This is
     /// required to get material referencing in katana (since in katana, all nodes
     /// are in a flat namespace, whereas Usd does not make any such requirement).
-    static std::string GenerateShadingNodeHandle(
+    USDKATANA_API static std::string GenerateShadingNodeHandle(
         const UsdPrim& shadingNode);
 
     // Scan the model hierarchy for models with kind=camera.
@@ -109,12 +115,14 @@ struct PxrUsdKatanaUtils {
 
     /// Convert the given SdfPath in the UsdStage to the corresponding
     /// katana location, given a scenegraph generator configuration.
+    USDKATANA_API
     static std::string ConvertUsdPathToKatLocation(
             const SdfPath &path,
             const std::string &isolatePathString,
             const std::string &rootPathString,
             const std::string &sessionPathString = "",
             bool allowOutsideIsolation = false);
+    USDKATANA_API
     static std::string ConvertUsdPathToKatLocation(
             const SdfPath &path,
             const PxrUsdKatanaUsdInPrivateData& data,
@@ -127,10 +135,10 @@ struct PxrUsdKatanaUtils {
     /// USD Looks can have Katana child-parent relationships, which means that
     /// we'll have to do some extra processing to find the correct path that
     /// these resolve to
-    static std::string _GetDisplayGroup(
+    USDKATANA_API static std::string _GetDisplayGroup(
             const UsdPrim &prim,
             const SdfPath& path);
-    static std::string _GetDisplayName(const UsdPrim &prim);
+    USDKATANA_API static std::string _GetDisplayName(const UsdPrim &prim);
     USDKATANA_API static std::string ConvertUsdMaterialPathToKatLocation(
             const SdfPath &path,
             const PxrUsdKatanaUsdInPrivateData& data);
@@ -147,12 +155,12 @@ struct PxrUsdKatanaUtils {
 
     // this finds prims with kind=subcomponent, increasingly used in complex
     // Sets models.
-    static bool PrimIsSubcomponent(const UsdPrim &prim);
+    USDKATANA_API static bool PrimIsSubcomponent(const UsdPrim &prim);
 
     /// Indicates if a given group should have a viewer proxy based on heuristics
     /// having to do with number of children and how many are components (non-group
     /// models).
-    static bool ModelGroupNeedsProxy(const UsdPrim &prim);
+    USDKATANA_API static bool ModelGroupNeedsProxy(const UsdPrim &prim);
 
     /// Creates the 'proxies' group attribute for consumption by the viewer.
     USDKATANA_API static FnKat::GroupAttribute GetViewerProxyAttr(
@@ -170,16 +178,16 @@ struct PxrUsdKatanaUtils {
 
     /// Returns the asset name for the given prim.  It should be a model.  This
     /// will fallback to the name of the prim.
-    static std::string GetAssetName(const UsdPrim& prim);
+    USDKATANA_API static std::string GetAssetName(const UsdPrim& prim);
 
     /// Returns the model instance name of the given prim, based on its
     /// RiAttribute-encoding, and falling back to its prim name.
-    static std::string GetModelInstanceName(const UsdPrim& prim);
+    USDKATANA_API static std::string GetModelInstanceName(const UsdPrim& prim);
 
     /// Returns true if the prim is a Model and is an Assembly or Component.
     /// Currently, we're only using this for determining when to log an error
     /// when accessing model data.
-    static bool IsModelAssemblyOrComponent(const UsdPrim& prim);
+    USDKATANA_API static bool IsModelAssemblyOrComponent(const UsdPrim& prim);
 
     /// \}
 

--- a/lib/vtKatana/CMakeLists.txt
+++ b/lib/vtKatana/CMakeLists.txt
@@ -2,6 +2,7 @@ set(PXR_PACKAGE vtKatana)
 
 pxr_shared_library(${PXR_PACKAGE}
     LIBRARIES
+        arch
         gf
         tf
         vt

--- a/plugin/pxrUsdIn/CMakeLists.txt
+++ b/plugin/pxrUsdIn/CMakeLists.txt
@@ -11,7 +11,7 @@ pxr_plugin(${PXR_PACKAGE}
         usdKatana
         katanaPluginApi
         usdGeom
-        ${vtKatana_LIBRARY}
+        vtKatana
         Boost::system
         Boost::date_time
 


### PR DESCRIPTION
Changes:
- Adding new libraries to lookup to FindUSD.cmake
- Adding new dependencies to usdKatana
- Adding a dependency to arch to vtKatana
- Setting the dependencies to PUBLIC in pxr_library, so they will be inherited

Fixes #11