### PR TITLE
Apply PointBased `accelerations` attribute to `geometry.point.accel` attr

### DIFF
--- a/lib/usdKatana/readBasisCurves.cpp
+++ b/lib/usdKatana/readBasisCurves.cpp
@@ -216,6 +216,14 @@ PxrUsdKatanaReadBasisCurves(
         attrs.set("geometry.point.v", velocityAttr);
     }
 
+    // acceleration
+    FnKat::Attribute accelAttr =
+        PxrUsdKatanaGeomGetAccelerationAttr(basisCurves, data);
+    if (accelAttr.isValid())
+    {
+        attrs.set("geometry.point.accel", accelAttr);
+    }
+
     // Add SPT_HwColor primvar
     attrs.set("geometry.arbitrary.SPT_HwColor", 
               PxrUsdKatanaGeomGetDisplayColorAttr(basisCurves, data));

--- a/lib/usdKatana/readGprim.cpp
+++ b/lib/usdKatana/readGprim.cpp
@@ -280,5 +280,14 @@ PxrUsdKatanaGeomGetVelocityAttr(
 
 }
 
+Foundry::Katana::Attribute
+PxrUsdKatanaGeomGetAccelerationAttr(
+    const UsdGeomPointBased& points,
+    const PxrUsdKatanaUsdInPrivateData& data)
+{
+    return _ConvertGeomAttr<GfVec3f, FnKat::FloatAttribute>(
+            points.GetAccelerationsAttr(), 3, data);
+}
+
 PXR_NAMESPACE_CLOSE_SCOPE
 

--- a/lib/usdKatana/readGprim.h
+++ b/lib/usdKatana/readGprim.h
@@ -71,6 +71,11 @@ PxrUsdKatanaGeomGetVelocityAttr(
     const UsdGeomPointBased& points,
     const PxrUsdKatanaUsdInPrivateData& data);
 
+Foundry::Katana::Attribute
+PxrUsdKatanaGeomGetAccelerationAttr(
+    const UsdGeomPointBased& points,
+    const PxrUsdKatanaUsdInPrivateData& data);
+
 
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/usdKatana/readMesh.cpp
+++ b/lib/usdKatana/readMesh.cpp
@@ -276,6 +276,13 @@ PxrUsdKatanaReadMesh(
         attrs.set("geometry.point.v", velocityAttr);
     }
 
+    // acceleration
+    FnKat::Attribute accelAttr = PxrUsdKatanaGeomGetAccelerationAttr(mesh, data);
+    if (accelAttr.isValid())
+    {
+        attrs.set("geometry.point.accel", accelAttr);
+    }
+
     FnKat::GroupAttribute polyAttr = _GetPolyAttr(mesh, currentTime);
     
     attrs.set("geometry.poly", polyAttr);

--- a/lib/usdKatana/readPoints.cpp
+++ b/lib/usdKatana/readPoints.cpp
@@ -100,6 +100,14 @@ PxrUsdKatanaReadPoints(
         attrs.set("geometry.point.v", velocitiesAttr);
     }
 
+    // acceleration
+    FnKat::Attribute accelAttr =
+        PxrUsdKatanaGeomGetAccelerationAttr(points, data);
+    if (accelAttr.isValid())
+    {
+        attrs.set("geometry.point.accel", accelAttr);
+    }
+
     // normals
     FnKat::Attribute normalsAttr = PxrUsdKatanaGeomGetNormalAttr(points, data);
     if (normalsAttr.isValid())


### PR DESCRIPTION
This change adds reading of the `accelerations` attribute from prim schema types which derive from the `PointBased` schema and are supported by usdKatana (currently `Mesh`, `Points`, and `BasisCurves`). This is a change we've made internally to support the use of acceleration data when computing velocity-based motion samples in Katana for point-based prims with variable topology and/or point counts.

The `accelerations` attribute is read in as `geometry.point.accel`.

Resolves #13.