### PR TITLE
USD 26.03 compatibility

### DIFF
--- a/cmake/macros/SetupInterfaces.cmake
+++ b/cmake/macros/SetupInterfaces.cmake
@@ -109,7 +109,7 @@ function(add_python_interface)
         set(Python3_VERSION_MAJOR ${KATANA_PYTHON_VERSION_MAJOR} PARENT_SCOPE)
         set(Python3_VERSION_MINOR ${KATANA_PYTHON_VERSION_MINOR} PARENT_SCOPE)
     elseif(DEFINED Python3_ROOT_DIR)
-        find_package(Python COMPONENTS Interpreter Development REQUIRED)
+        find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
         if(Python3_INCLUDE_DIRS AND Python3_LIBRARIES AND Python3_EXECUTABLE)
             # add_library(Python::Python INTERFACE IMPORTED)
             set_target_properties(Python3::Python

--- a/cmake/macros/SetupInterfaces.cmake
+++ b/cmake/macros/SetupInterfaces.cmake
@@ -136,7 +136,6 @@ function(add_python_interface)
     endif()
 endfunction() #add_python_interface
 
-
 function(add_tbb_interface)
     if(USE_KATANA_TBB)
         # We want to create CMake interfaces to make linking neater and to
@@ -145,6 +144,8 @@ function(add_tbb_interface)
             return()
         endif()
         add_library(TBB::tbb INTERFACE IMPORTED)
+        add_library(TBB::tbbmalloc INTERFACE IMPORTED)
+        add_library(TBB::tbbmalloc_proxy INTERFACE IMPORTED)
         if(KATANA_API_LOCATION)
             if(UNIX)
                 set(tbb_lib_suffix so)
@@ -162,6 +163,24 @@ function(add_tbb_interface)
                     INTERFACE_LINK_LIBRARIES
                         "${KATANA_API_LOCATION}/bin/${tbb_lib_prefix}tbb.${tbb_lib_suffix}"
             )
+            set_target_properties(TBB::tbbmalloc
+                PROPERTIES
+                    INTERFACE_INCLUDE_DIRECTORIES
+                        "${KATANA_API_LOCATION}/external/tbb/include"
+                    INTERFACE_COMPILE_DEFINITIONS
+                        "__TBB_NO_IMPLICIT_LINKAGE=1"
+                    INTERFACE_LINK_LIBRARIES
+                        "${KATANA_API_LOCATION}/bin/${tbb_lib_prefix}tbbmalloc.${tbb_lib_suffix}"
+            )
+            set_target_properties(TBB::tbbmalloc_proxy
+                PROPERTIES
+                    INTERFACE_INCLUDE_DIRECTORIES
+                        "${KATANA_API_LOCATION}/external/tbb/include"
+                    INTERFACE_COMPILE_DEFINITIONS
+                        "__TBB_NO_IMPLICIT_LINKAGE=1"
+                    INTERFACE_LINK_LIBRARIES
+                        "${KATANA_API_LOCATION}/bin/${tbb_lib_prefix}tbbmalloc_proxy.${tbb_lib_suffix}"
+            )
         else()
             message(FATAL_ERROR "KATANA_API_LOCATION must be set if using the"
                 " USE_KATANA_TBB option")
@@ -171,12 +190,26 @@ function(add_tbb_interface)
     else()
         find_package(TBB REQUIRED)
         add_library(TBB::tbb INTERFACE IMPORTED)
+        add_library(TBB::tbbmalloc INTERFACE IMPORTED)
+        add_library(TBB::tbbmalloc_proxy INTERFACE IMPORTED)
         if(TBB_tbb_FOUND)
             set_target_properties(TBB::tbb
                 PROPERTIES
                     INTERFACE_INCLUDE_DIRECTORIES "${TBB_INCLUDE_DIRS}"
                     INTERFACE_COMPILE_DEFINITIONS "__TBB_NO_IMPLICIT_LINKAGE=1"
                     INTERFACE_LINK_LIBRARIES "${TBB_tbb_LIBRARY}"
+            )
+            set_target_properties(TBB::tbbmalloc
+                PROPERTIES
+                    INTERFACE_INCLUDE_DIRECTORIES "${TBB_INCLUDE_DIRS}"
+                    INTERFACE_COMPILE_DEFINITIONS "__TBB_NO_IMPLICIT_LINKAGE=1"
+                    INTERFACE_LINK_LIBRARIES "${TBB_tbbmalloc_LIBRARY}"
+            )
+            set_target_properties(TBB::tbbmalloc_proxy
+                PROPERTIES
+                    INTERFACE_INCLUDE_DIRECTORIES "${TBB_INCLUDE_DIRS}"
+                    INTERFACE_COMPILE_DEFINITIONS "__TBB_NO_IMPLICIT_LINKAGE=1"
+                    INTERFACE_LINK_LIBRARIES "${TBB_tbbmalloc_proxy_LIBRARY}"
             )
         else()
             message(FATAL_ERROR "Unable to find tbb library")

--- a/cmake/macros/SetupInterfaces.cmake
+++ b/cmake/macros/SetupInterfaces.cmake
@@ -21,7 +21,7 @@
 # language governing permissions and limitations under the Apache License.
 
 
-function(add_boost_interface)
+macro(add_boost_interface)
     if(NOT DEFINED Python3_VERSION_MAJOR)
     message(FATL_ERROR "Unable to read Python3_VERSION_MAJOR from Python "
         "FindPackage, therefore unable to build Boost_PYTHON_COMPONENT")
@@ -72,10 +72,10 @@ function(add_boost_interface)
             thread
             system
         REQUIRED)
-endfunction(add_boost_interface) # add_boost_interface
+endmacro() # add_boost_interface
 
 
-function(add_python_interface)
+macro(add_python_interface)
     if (TARGET Python3::Python)
         return()
     endif()
@@ -125,7 +125,7 @@ function(add_python_interface)
             )
         endif()
     elseif(DEFINED Python3_DIR AND DEFINED Python3_EXECUTABLE)
-        find_package(Python CONFIG REQUIRED)
+        find_package(Python3 CONFIG REQUIRED)
     else()
         message(FATAL_ERROR "Cannot search for Python libraries, must"
             " specify either USE_KATANA_PYTHON to use the Python shipped "
@@ -134,9 +134,9 @@ function(add_python_interface)
             " custom cmake config"
         )
     endif()
-endfunction() #add_python_interface
+endmacro() #add_python_interface
 
-function(add_tbb_interface)
+macro(add_tbb_interface)
     if(USE_KATANA_TBB)
         # We want to create CMake interfaces to make linking neater and to
         # reduce complexity later in the build
@@ -215,10 +215,10 @@ function(add_tbb_interface)
             message(FATAL_ERROR "Unable to find tbb library")
         endif()
     endif() # If USE_KATANA_TBB
-endfunction() #add_tbb_interface
+endmacro() #add_tbb_interface
 
 
-function(add_usd_interface)
+macro(add_usd_interface)
     if(USE_KATANA_USD)
         set(USD_LIBRARY_DIR ${KATANA_API_LOCATION}/bin)
         set(USD_INCLUDE_DIR ${KATANA_API_LOCATION}/external/FnUSD/include)
@@ -240,4 +240,4 @@ function(add_usd_interface)
         endif()
         include(${USD_ROOT}/pxrConfig.cmake)
     endif()
-endfunction() #add_use_interface
+endmacro() #add_use_interface

--- a/cmake/macros/SetupInterfaces.cmake
+++ b/cmake/macros/SetupInterfaces.cmake
@@ -22,12 +22,12 @@
 
 
 function(add_boost_interface)
-    if(NOT DEFINED Python_VERSION_MAJOR)
-    message(FATL_ERROR "Unable to read Python_VERSION_MAJOR from Python "
+    if(NOT DEFINED Python3_VERSION_MAJOR)
+    message(FATL_ERROR "Unable to read Python3_VERSION_MAJOR from Python "
         "FindPackage, therefore unable to build Boost_PYTHON_COMPONENT")
     endif()
     set(Boost_PYTHON_COMPONENT
-            python${Python_VERSION_MAJOR}${Python_VERSION_MINOR})
+            python${Python3_VERSION_MAJOR}${Python3_VERSION_MINOR})
     set(Boost_PYTHON_COMPONENT ${Boost_PYTHON_COMPONENT} PARENT_SCOPE)
     if(USE_KATANA_BOOST)
         # Setup the variables to use the Katana builds.
@@ -76,61 +76,61 @@ endfunction(add_boost_interface) # add_boost_interface
 
 
 function(add_python_interface)
-    if (TARGET Python::Python)
+    if (TARGET Python3::Python)
         return()
     endif()
 
     if(USE_KATANA_PYTHON)
         include(${KATANA_API_LOCATION}/plugin_apis/cmake/python-variables.cmake)
 
-        add_library(Python::Python INTERFACE IMPORTED)
-        # Parent_scope required for Python_EXECUTABLE variable is used in
+        add_library(Python3::Python INTERFACE IMPORTED)
+        # Parent_scope required for Python3_EXECUTABLE variable is used in
         # the parent cmake files.
-        set(Python_EXECUTABLE
+        set(Python3_EXECUTABLE
             ${KATANA_API_LOCATION}/bin/${KATANA_PYTHON_EXECUTABLE}
             PARENT_SCOPE)
-        set(Python_LIBRARIES
+        set(Python3_LIBRARIES
             ${KATANA_API_LOCATION}/bin/${KATANA_PYTHON_LIB})
 
-        set(Python_INCLUDE_DIRS ${KATANA_API_LOCATION}/bin/${KATANA_PYTHON_INCLUDE_FOLDER})
+        set(Python3_INCLUDE_DIRS ${KATANA_API_LOCATION}/bin/${KATANA_PYTHON_INCLUDE_FOLDER})
         set(_py_dir python${KATANA_PYTHON_VERSION_MAJOR}.${KATANA_PYTHON_VERSION_MINOR})
         if(EXISTS ${KATANA_API_LOCATION}/bin/${KATANA_PYTHON_INCLUDE_FOLDER}/${_py_dir})
-            list(APPEND Python_INCLUDE_DIRS ${KATANA_API_LOCATION}/bin/${KATANA_PYTHON_INCLUDE_FOLDER}/${_py_dir})
+            list(APPEND Python3_INCLUDE_DIRS ${KATANA_API_LOCATION}/bin/${KATANA_PYTHON_INCLUDE_FOLDER}/${_py_dir})
         endif()
         if(EXISTS ${KATANA_API_LOCATION}/bin/${KATANA_PYTHON_INCLUDE_FOLDER}/${_py_dir}m)
-            list(APPEND Python_INCLUDE_DIRS ${KATANA_API_LOCATION}/bin/${KATANA_PYTHON_INCLUDE_FOLDER}/${_py_dir}m)
+            list(APPEND Python3_INCLUDE_DIRS ${KATANA_API_LOCATION}/bin/${KATANA_PYTHON_INCLUDE_FOLDER}/${_py_dir}m)
         endif()
         unset(_py_dir)
-        set_target_properties(Python::Python
+        set_target_properties(Python3::Python
             PROPERTIES
-                INTERFACE_INCLUDE_DIRECTORIES "${Python_INCLUDE_DIRS}"
-                INTERFACE_LINK_LIBRARIES "${Python_LIBRARIES}"
+                INTERFACE_INCLUDE_DIRECTORIES "${Python3_INCLUDE_DIRS}"
+                INTERFACE_LINK_LIBRARIES "${Python3_LIBRARIES}"
         )
-        set(Python_VERSION_MAJOR ${KATANA_PYTHON_VERSION_MAJOR} PARENT_SCOPE)
-        set(Python_VERSION_MINOR ${KATANA_PYTHON_VERSION_MINOR} PARENT_SCOPE)
-    elseif(DEFINED Python_ROOT_DIR)
+        set(Python3_VERSION_MAJOR ${KATANA_PYTHON_VERSION_MAJOR} PARENT_SCOPE)
+        set(Python3_VERSION_MINOR ${KATANA_PYTHON_VERSION_MINOR} PARENT_SCOPE)
+    elseif(DEFINED Python3_ROOT_DIR)
         find_package(Python COMPONENTS Interpreter Development REQUIRED)
-        if(Python_INCLUDE_DIRS AND Python_LIBRARIES AND Python_EXECUTABLE)
+        if(Python3_INCLUDE_DIRS AND Python3_LIBRARIES AND Python3_EXECUTABLE)
             # add_library(Python::Python INTERFACE IMPORTED)
-            set_target_properties(Python::Python
+            set_target_properties(Python3::Python
                 PROPERTIES
-                    INTERFACE_INCLUDE_DIRECTORIES "${Python_INCLUDE_DIRS}"
-                    INTERFACE_LINK_LIBRARIES "${Python_LIBRARIES}"
+                    INTERFACE_INCLUDE_DIRECTORIES "${Python3_INCLUDE_DIRS}"
+                    INTERFACE_LINK_LIBRARIES "${Python3_LIBRARIES}"
             )
         else()
             message(FATAL_ERROR "Cannot find Python libraries or headers"
-                " using find_package(Python). Ensure the Python_ROOT_DIR is"
-                " specified correctly. Or Ensure that Python_EXECUTABLE is"
+                " using find_package(Python). Ensure the Python3_ROOT_DIR is"
+                " specified correctly. Or Ensure that Python3_EXECUTABLE is"
                 " defined in your build script"
             )
         endif()
-    elseif(DEFINED Python_DIR AND DEFINED Python_EXECUTABLE)
+    elseif(DEFINED Python3_DIR AND DEFINED Python3_EXECUTABLE)
         find_package(Python CONFIG REQUIRED)
     else()
         message(FATAL_ERROR "Cannot search for Python libraries, must"
             " specify either USE_KATANA_PYTHON to use the Python shipped "
-            " with Katana, Python_ROOT_DIR to use default CMake"
-            " FindPackage or Python_DIR and Python_EXECUTABLE to use a"
+            " with Katana, Python3_ROOT_DIR to use default CMake"
+            " FindPackage or Python3_DIR and Python3_EXECUTABLE to use a"
             " custom cmake config"
         )
     endif()

--- a/cmake/macros/Support.cmake
+++ b/cmake/macros/Support.cmake
@@ -218,7 +218,7 @@ function(pxr_library NAME)
         ${NAME}
         PRIVATE
         $<$<CXX_COMPILER_ID:GNU>:-Wall -Wno-unused-but-set-variable -Wno-deprecated -Wno-unused-local-typedefs -Werror=narrowing>
-        $<$<CXX_COMPILER_ID:MSVC>:/W4 /wd4267 /wd4100 /wd4702 /wd4244 /wd4800 /wd4996 /wd4456 /wd4127 /wd4701 /wd4305 /wd4838 /wd4624 /wd4506 /wd4245 /wd4996 /DWIN32_LEAN_AND_MEAN /DNOMINMAX /DNOGDI /FIiso646.h>
+        $<$<CXX_COMPILER_ID:MSVC>:/W4 /wd4267 /wd4100 /wd4702 /wd4244 /wd4800 /wd4996 /wd4456 /wd4127 /wd4701 /wd4305 /wd4838 /wd4624 /wd4506 /wd4245 /wd4996 /EHsc /DWIN32_LEAN_AND_MEAN /DNOMINMAX /DNOGDI /FIiso646.h>
         $<$<CONFIG:Debug>:-DTBB_USE_DEBUG=1> # needed on Windows to avoid errors when Python changes _DEBUG
         $<$<CONFIG:Debug>:-DBOOST_DEBUG_PYTHON> # needed on Windows to help with the autolink library name (even though adding BOOST_ALL_NO_LIB doesn't seem to disable this)
     )

--- a/cmake/macros/Support.cmake
+++ b/cmake/macros/Support.cmake
@@ -263,7 +263,7 @@ function(pxr_library NAME)
             ${pythonWrapperModuleName}
             PRIVATE
             $<$<CXX_COMPILER_ID:GNU>:-Wall -Wno-deprecated -Wno-unused-local-typedefs>
-            $<$<CXX_COMPILER_ID:MSVC>:/W4 /wd4244 /wd4305 /wd4100 /wd4459 /wd4996 /DWIN32_LEAN_AND_MEAN /DNOMINMAX>
+            $<$<CXX_COMPILER_ID:MSVC>:/W4 /wd4244 /wd4305 /wd4100 /wd4459 /wd4996 /EHsc /DWIN32_LEAN_AND_MEAN /DNOMINMAX>
             $<$<CONFIG:Debug>:-DBOOST_DEBUG_PYTHON> # needed on Windows to help with the autolink library name (even though adding BOOST_ALL_NO_LIB doesn't seem to disable this)
         )
         target_link_libraries(

--- a/cmake/macros/UsdUtils.cmake
+++ b/cmake/macros/UsdUtils.cmake
@@ -170,7 +170,7 @@ function(_install_python LIBRARY_NAME)
                 set(pythonexe ${BIN_BUNDLE_PATH}/python.sh)
               endif()
             else()
-              set(pythonexe ${Python_EXECUTABLE})
+              set(pythonexe ${Python3_EXECUTABLE})
             endif()
             _replace_root_python_module(
                 ${CMAKE_CURRENT_SOURCE_DIR}/${file}

--- a/cmake/modules/FindTBB.cmake
+++ b/cmake/modules/FindTBB.cmake
@@ -200,13 +200,18 @@ if(NOT TBB_FOUND)
   ##################################
 
   if(TBB_INCLUDE_DIRS)
-    file(READ "${TBB_INCLUDE_DIRS}/tbb/tbb_stddef.h" _tbb_version_file)
+    # Use new oneTBB version header if it exists.
+    if(EXISTS "${TBB_INCLUDE_DIRS}/oneapi/tbb/version.h")
+      file(READ "${TBB_INCLUDE_DIRS}/oneapi/tbb/version.h" _tbb_version_file)
+    else()
+      file(READ "${TBB_INCLUDE_DIRS}/tbb/tbb_stddef.h" _tbb_version_file)
+    endif()
     string(REGEX REPLACE ".*#define TBB_VERSION_MAJOR ([0-9]+).*" "\\1"
-            TBB_VERSION_MAJOR "${_tbb_version_file}")
+        TBB_VERSION_MAJOR "${_tbb_version_file}")
     string(REGEX REPLACE ".*#define TBB_VERSION_MINOR ([0-9]+).*" "\\1"
-            TBB_VERSION_MINOR "${_tbb_version_file}")
+        TBB_VERSION_MINOR "${_tbb_version_file}")
     string(REGEX REPLACE ".*#define TBB_INTERFACE_VERSION ([0-9]+).*" "\\1"
-            TBB_INTERFACE_VERSION "${_tbb_version_file}")
+        TBB_INTERFACE_VERSION "${_tbb_version_file}")
     set(TBB_VERSION "${TBB_VERSION_MAJOR}.${TBB_VERSION_MINOR}")
   endif()
 

--- a/cmake/modules/FindUSD.cmake
+++ b/cmake/modules/FindUSD.cmake
@@ -25,25 +25,32 @@
 set(USD_LIBRARIES
     ar
     arch
+    boost
     cameraUtil
+    geomUtil
     gf
     hd
+    hdar
     hf
     hio
     js
     kind
     pcp
+    pegtl
     plug
     pxOsd
+    python
     sdf
     sdr
     tf
+    ts
     trace
     usd
     usdGeom
     usdHydra
     usdImaging
     usdLux
+    usdRender
     usdRi
     usdShade
     usdSkel
@@ -68,34 +75,41 @@ set(USD_LIBRARIES
 # endforeach()
 # ------------------------------------------------------------------------------
 
-set(USD_ar_DEPENDENCIES arch;tf;plug;vt;Boost::${Boost_PYTHON_COMPONENT})
+set(USD_ar_DEPENDENCIES arch;js;tf;plug;vt;python;TBB::tbb;Python3::Python)
 set(USD_arch_DEPENDENCIES )
+set(USD_boost_DEPENDENCIES )
 set(USD_cameraUtil_DEPENDENCIES tf;gf)
-set(USD_gf_DEPENDENCIES arch;tf)
-set(USD_hd_DEPENDENCIES plug;tf;trace;vt;work;sdf;cameraUtil;hf;pxOsd;TBB::tbb)
+set(USD_gf_DEPENDENCIES arch;tf;python;Python3::Python)
+set(USD_geomUtil_DEPENDENCIES arch;gf;tf;vt;pxOsd)
+set(USD_hd_DEPENDENCIES plug;tf;trace;vt;work;sdf;cameraUtil;hf;pxOsd;sdr;TBB::tbb)
+set(USD_hdar_DEPENDENCIES hd;ar)
 set(USD_hf_DEPENDENCIES plug;tf;trace)
 set(USD_hio_DEPENDENCIES arch;js;plug;tf;vt;trace;ar;hf)
 set(USD_js_DEPENDENCIES tf)
 set(USD_kind_DEPENDENCIES tf;plug)
-set(USD_pcp_DEPENDENCIES tf;trace;vt;sdf;work;ar;Boost::${Boost_PYTHON_COMPONENT};TBB::tbb)
-set(USD_plug_DEPENDENCIES arch;tf;js;trace;work;Boost::${Boost_PYTHON_COMPONENT};TBB::tbb)
-set(USD_pxOsd_DEPENDENCIES tf;gf;vt;Boost::${Boost_PYTHON_COMPONENT})
-set(USD_sdf_DEPENDENCIES arch;tf;gf;trace;vt;work;ar;Boost::${Boost_PYTHON_COMPONENT})
-set(USD_sdr_DEPENDENCIES tf;vt;ar;sdf;Boost::${Boost_PYTHON_COMPONENT})
-set(USD_tf_DEPENDENCIES arch;Python::Python;Boost::${Boost_PYTHON_COMPONENT};TBB::tbb)
-set(USD_trace_DEPENDENCIES arch;js;tf;Boost::${Boost_PYTHON_COMPONENT};TBB::tbb)
-set(USD_usd_DEPENDENCIES arch;kind;pcp;sdf;ar;plug;tf;trace;vt;work;Boost::${Boost_PYTHON_COMPONENT};TBB::tbb)
-set(USD_usdGeom_DEPENDENCIES js;tf;plug;vt;sdf;trace;usd;work;Boost::${Boost_PYTHON_COMPONENT};TBB::tbb)
+set(USD_pcp_DEPENDENCIES tf;trace;vt;sdf;work;ar;python;TBB::tbb;Python3::Python)
+set(USD_pegtl_DEPENDENCIES arch)
+set(USD_plug_DEPENDENCIES arch;tf;js;trace;work;TBB::tbb)
+set(USD_pxOsd_DEPENDENCIES tf;gf;vt)
+set(USD_python_DEPENDENCIES boost;Python3::Python)
+set(USD_sdf_DEPENDENCIES arch;tf;gf;pegtl;trace;ts;vt;work;ar;python;TBB::tbb;Python3::Python)
+set(USD_sdr_DEPENDENCIES arch;plug;trace;tf;vt;work;ar;sdf)
+set(USD_tf_DEPENDENCIES arch;python;TBB::tbb;Python3::Python)
+set(USD_ts_DEPENDENCIES vt;gf;tf)
+set(USD_trace_DEPENDENCIES arch;js;tf;TBB::tbb)
+set(USD_usd_DEPENDENCIES arch;kind;pcp;sdf;ar;plug;tf;trace;ts;vt;work;python;TBB::tbb;Python3::Python)
+set(USD_usdGeom_DEPENDENCIES js;tf;plug;vt;sdf;trace;usd;work;TBB::tbb)
 set(USD_usdHydra_DEPENDENCIES tf;usd;usdShade)
-set(USD_usdImaging_DEPENDENCIES gf;tf;plug;trace;vt;work;hd;pxOsd;sdf;usd;usdGeom;usdLux;usdShade;usdVol;ar;TBB::tbb)
+set(USD_usdImaging_DEPENDENCIES gf;tf;plug;trace;vt;work;geomUtil;hd;hdar;hio;pxOsd;sdf;usd;usdGeom;usdLux;usdRender;usdShade;usdSkel;usdVol;ar;TBB::tbb)
 set(USD_usdLux_DEPENDENCIES tf;vt;sdf;usd;usdGeom;usdShade)
-set(USD_usdRi_DEPENDENCIES tf;vt;sdf;usd;usdShade;usdGeom;usdLux;Boost::${Boost_PYTHON_COMPONENT})
-set(USD_usdShade_DEPENDENCIES tf;vt;sdf;sdr;usd;usdGeom)
-set(USD_usdSkel_DEPENDENCIES arch;gf;tf;trace;vt;work;sdf;usd;usdGeom;Boost::${Boost_PYTHON_COMPONENT};TBB::tbb)
+set(USD_usdRender_DEPENDENCIES gf;tf;usd;usdGeom;usdShade)
+set(USD_usdRi_DEPENDENCIES tf;vt;sdf;usd;usdShade;usdGeom)
+set(USD_usdShade_DEPENDENCIES tf;vt;js;sdf;sdr;usd;usdGeom;TBB::tbb)
+set(USD_usdSkel_DEPENDENCIES arch;gf;tf;trace;vt;work;sdf;usd;usdGeom;TBB::tbb)
 set(USD_usdUI_DEPENDENCIES tf;vt;sdf;usd)
-set(USD_usdUtils_DEPENDENCIES arch;tf;gf;sdf;usd;usdGeom;Boost::${Boost_PYTHON_COMPONENT})
+set(USD_usdUtils_DEPENDENCIES arch;tf;gf;sdf;usd;usdGeom;usdShade;usdUI;TBB::tbb)
 set(USD_usdVol_DEPENDENCIES tf;usd;usdGeom)
-set(USD_vt_DEPENDENCIES arch;tf;gf;trace;Boost::${Boost_PYTHON_COMPONENT};TBB::tbb)
+set(USD_vt_DEPENDENCIES arch;tf;gf;trace;python;TBB::tbb;Python3::Python)
 set(USD_work_DEPENDENCIES tf;trace;TBB::tbb)
 
 if(NOT DEFINED USD_LIBRARY_DIR)


### PR DESCRIPTION
I've successfully built the KatanaUsdPlugins against USD 26.03 with Windows 11/Katana 9.0v1, and thought I would add the changes I made to make the build succeed.

Main changes:
- Add new dependencies to FindUSD
- Allow oneTBB to be found as well as TBB 2020
- Enable exception handling flag for MSVC (/EHsc)
- Change SetupInterfaces functinos to macros so the resulting variables are recognised in the parent scope
- Look for Python3 specifically (since this is what USD looks for now)
- Add TBB:tbbmalloc and TBB:tbbmalloc_proxy interfaces

--
Jonah Newton
Pipeline TD
Flying Bark Productions